### PR TITLE
Bugfix/ipv6

### DIFF
--- a/lib/CtrlxDatalayerSubscription.js
+++ b/lib/CtrlxDatalayerSubscription.js
@@ -114,8 +114,8 @@ class CtrlxDatalayerSubscription extends EventEmitter {
 
     // Arguments are given as query parameter.
     // IPv6: We have to use IPv6 square brackets for valid url
-    let hostname = this._isIPv6 ? '[' + this._hostname + ']' : this._hostname;
-    let url = `https://${hostname}:${this._port}/automation/api/v2/events?nodes=${this._nodes}`;
+    let urlhostname = this._isIPv6 ? '[' + this._hostname + ']' : this._hostname;
+    let url = `https://${urlhostname}:${this._port}/automation/api/v2/events?nodes=${this._nodes}`;
     if (typeof this._publishIntervalMs !== 'undefined') {
       url += `&publishIntervalMs=${this._publishIntervalMs}`;
     }
@@ -124,6 +124,7 @@ class CtrlxDatalayerSubscription extends EventEmitter {
     // To establish an event stream we use the standardized EventSource class.
     let sub = this;
     const eventSourceInitDict = {
+      hostname: this._hostname,                 // sets the hostname (without enclosing brackets) for enabling IPv6 support on linux
       initialRetryDelayMillis: 1000,            // sets initial retry delay to 1 seconds
       maxBackoffMillis: 10000,                  // enables backoff, with a maximum of 10 seconds
       retryResetIntervalMillis: 60000,          // backoff will reset to initial level if stream got an event at least 60 seconds before failing

--- a/package.json
+++ b/package.json
@@ -41,17 +41,17 @@
     "eslint-plugin-mocha": "^10.0.4",
     "express": "^4.18.0",
     "jwt-simple": "^0.5.6",
-    "mocha": "^9.2.0",
-    "node-red": "^2.1.6",
-    "node-red-node-test-helper": "^0.2.7",
+    "mocha": "^10.0.0",
+    "node-red": "^3.0.2",
+    "node-red-node-test-helper": "^0.3.0",
     "nyc": "^15.1.0",
     "ssestream": "^1.1.0",
     "supports-color": "^9.2.2"
   },
   "dependencies": {
     "atob": "^2.1.2",
-    "debug": "^4.3.3",
-    "launchdarkly-eventsource": "^1.4.3",
+    "debug": "^4.3.4",
+    "launchdarkly-eventsource": "^1.4.4",
     "mustache": "^4.2.0"
   },
   "scripts": {

--- a/test/CtrlxCore.test.js
+++ b/test/CtrlxCore.test.js
@@ -71,9 +71,18 @@ describe('CtrlxCore', function() {
       expect(CtrlxCore._parseHost('127.0.0.1')).to.deep.equal({ 'hostname': '127.0.0.1', 'port': 443 })
 
       // IPv6
+      expect(net.isIPv6('::1')).to.equal(true)
+      expect(net.isIPv6('::1%eth0')).to.equal(true)
+      expect(net.isIPv6('fe80::260:34ff:fe08:db2')).to.equal(true)
+      expect(net.isIPv6('fe80::260:34ff:fe08:db2%eth0')).to.equal(true)
+
       expect(CtrlxCore._parseHost('fe80::260:34ff:fe08:db2')).to.deep.equal({ 'hostname': 'fe80::260:34ff:fe08:db2', 'port': 443 })
       expect(CtrlxCore._parseHost('[fe80::260:34ff:fe08:db2]')).to.deep.equal({ 'hostname': 'fe80::260:34ff:fe08:db2', 'port': 443 })
       expect(CtrlxCore._parseHost('[fe80::260:34ff:fe08:db2]:8443')).to.deep.equal({ 'hostname': 'fe80::260:34ff:fe08:db2', 'port': 8443 })
+
+      expect(CtrlxCore._parseHost('fe80::260:34ff:fe08:db2%eth0')).to.deep.equal({ 'hostname': 'fe80::260:34ff:fe08:db2%eth0', 'port': 443 })
+      expect(CtrlxCore._parseHost('[fe80::260:34ff:fe08:db2%eth0]')).to.deep.equal({ 'hostname': 'fe80::260:34ff:fe08:db2%eth0', 'port': 443 })
+      expect(CtrlxCore._parseHost('[fe80::260:34ff:fe08:db2%eth0]:8443')).to.deep.equal({ 'hostname': 'fe80::260:34ff:fe08:db2%eth0', 'port': 8443 })
 
       expect(CtrlxCore._parseHost('::1')).to.deep.equal({ 'hostname': '::1', 'port': 443 })
       expect(CtrlxCore._parseHost('[::1]')).to.deep.equal({ 'hostname': '::1', 'port': 443 })

--- a/test/CtrlxCore.test.js
+++ b/test/CtrlxCore.test.js
@@ -25,7 +25,7 @@
  */
 
 
-
+const net = require('net');
 const expect = require('chai').expect;
 const CtrlxCore = require('../lib/CtrlxCore')
 const CtrlxDatalayer = require('../lib/CtrlxDatalayerV2')


### PR DESCRIPTION
DL REQUEST: For IPV6 on ctrlX hardware (Ubuntu Core) the interface has to be suffixed e.g. fe80::260:34ff:fe85:dc61%eth0
DL SUBSCRIBE: EventSource currently does not support IPV6, so we have to ask the Maintainers (we're using a fork of launchdarkly not official EventSource project) to support/fix it or try for ourselves and submit a Pullrequest there (https://github.com/launchdarkly/js-eventsource). I couldn't get this to work after investing some time. Maybe we could try together.