### PR TITLE
fix: encode IpV6 % to %25 

### DIFF
--- a/lib/CtrlxDatalayerSubscription.js
+++ b/lib/CtrlxDatalayerSubscription.js
@@ -114,7 +114,7 @@ class CtrlxDatalayerSubscription extends EventEmitter {
 
     // Arguments are given as query parameter.
     // IPv6: We have to use IPv6 square brackets for valid url
-    let urlhostname = this._isIPv6 ? '[' + this._hostname + ']' : this._hostname;
+    let urlhostname = this._isIPv6 ? '[' + encodeURI(this._hostname) + ']' : this._hostname;
     let url = `https://${urlhostname}:${this._port}/automation/api/v2/events?nodes=` + encodeURIComponent(this._nodes.toString());
     if (typeof this._publishIntervalMs !== 'undefined') {
       url += `&publishIntervalMs=${this._publishIntervalMs}`;


### PR DESCRIPTION
(seems to work also, but recommended by lauchdarkly)

Note: Does not fix the IpV6 issue, so we have to wait for the fix here

https://github.com/launchdarkly/js-eventsource/pull/18