### PR TITLE
fix: timeout issues with change of default timeout in nodejs19

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,12 @@ Any use of the source code and related documents of this repository in applicati
 * 2023-07-17: 1.9.1  - fix: change sampling interval to microseconds                     
 * 2023-08-07: 1.9.2  - fix: automatic reconnect of subscription on reboot of control 
 * 2023-09-04: 1.9.3  - fix: subscription with ipv6 address that contains a zone index
+* 2024-03-13: 1.9.4  - fix: timeout of connection with Node.js v19. "Read timeout, received no data in undefinedms, assuming connection is dead".
 ```
   
 ## About
 
-Copyright © 2020-2023 Bosch Rexroth AG. All rights reserved.
+Copyright © 2020-2024 Bosch Rexroth AG. All rights reserved.
 
 <https://www.boschrexroth.com>
 
@@ -132,7 +133,7 @@ GERMANY
 
 MIT License
 
-Copyright (c) 2020-2023 Bosch Rexroth AG
+Copyright (c) 2020-2024 Bosch Rexroth AG
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/CtrlxDatalayerSubscription.js
+++ b/lib/CtrlxDatalayerSubscription.js
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2020-2022 Bosch Rexroth AG
+ * Copyright (c) 2020-2024 Bosch Rexroth AG
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -102,7 +102,7 @@ class CtrlxDatalayerSubscription extends EventEmitter {
 
     // SSE states and settings
     this._es = null;
-    this._timeout = 0;            // http timeout in ms, (0 = OS defaults)
+    this._timeout = 0;            // http timeout in ms, (0 = no timeout)
     this._noInternalReconnect = true;
     this._isEndByServer = false;
   }
@@ -232,7 +232,7 @@ class CtrlxDatalayerSubscription extends EventEmitter {
     });
 
     req.on('timeout', () => {
-      req.abort();
+      req.destroy();
     });
 
     req.on('error', (err) => {
@@ -306,7 +306,7 @@ class CtrlxDatalayerSubscription extends EventEmitter {
         jitterRatio: 0.5,                             // each delay will be reduced by a randomized jitter of up to 50%
         https: {
           rejectUnauthorized: false,                  // causes requests to succeed even if the certificate cannot be validated
-          servername: this._servername,
+          servername: this._servername
         },
         headers: {
           'Authorization': this._authorization,       // forward the authorization token
@@ -318,11 +318,17 @@ class CtrlxDatalayerSubscription extends EventEmitter {
           } else {
             return e.status !== 401;                  // always try reconnect, except for authorization problems
           }
-        }
+        },
+        agent: new https.Agent({ keepAlive: false })  // create a dedicated agent to have dedicated connection instance. Also disable the agent-keep-alive explicitly.
+                                                      // This is necessary because since node.js 19 the default behaviour was changed. 
+                                                      // https://nodejs.org/en/blog/announcements/v19-release-announce#https11-keepalive-by-default
       };
 
       if (this._keepaliveIntervalMs) {
         eventSourceInitDict['readTimeoutMillis'] = this._keepaliveIntervalMs + 5000;
+      } else {
+        // When no keepalive timeout is given, then we set the timeout to infinite to be sure, that the connection does not get closed.
+        eventSourceInitDict['readTimeoutMillis'] = 0;
       }
 
       // The EventSource object holds the connection to the server.
@@ -470,7 +476,11 @@ class CtrlxDatalayerSubscription extends EventEmitter {
       // @ts-ignore
       this._es.onretrying = undefined;
       // @ts-ignore
-      this._es.onerror = undefined;
+      this._es.onerror = (e) => { 
+        // ignore any pending errors in the pipeline, which might get emitted and result in an uncaught exception 
+        debug(`onerror(${e.type})`);
+        console.log("error after");
+      };
       // @ts-ignore
       this._es.onmessage = undefined;
       this._es.close();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-ctrlx-automation",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "Node-RED nodes for ctrlX AUTOMATION",
   "repository": {
     "type": "git",


### PR DESCRIPTION
fix: timeout of connection with Node.js v19. "Read timeout, received no data in undefinedms, assuming connection is dead".
related to: https://nodejs.org/en/blog/announcements/v19-release-announce#https11-keepalive-by-default