### PR TITLE
Feature/moreerror

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,20 +4,19 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: sudo setcap 'cap_net_bind_service=+ep' $(readlink -f $(which node))
-    - run: npm install --loglevel verbose
-    - run: npm run build --if-present
-    - run: npm run test_with_coverage --unsafe-perm
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: sudo setcap 'cap_net_bind_service=+ep' $(readlink -f $(which node))
+      - run: npm install --loglevel verbose
+      - run: npm run build --if-present
+      - run: npm run test_with_coverage --unsafe-perm

--- a/README.md
+++ b/README.md
@@ -124,6 +124,31 @@ Any use of the source code and related documents of this repository in applicati
 * 2025-01-27: 1.9.8  - fix: no support for raw binary data (types/datalayer/raw). E.g. for some Ethercat nodes, returned now as a buffer for further processing.
 * 2026-04-02: 1.9.9  - chore: upgrade internal development dependencies to newest version to mitigate for vulnerabilities. No runtime changes.
                      - fix: allow sampling interval = 0 in subscription properties, which indicates a real-time (RT) lossless subscriptions.
+* 2026-07-08: 2.0.0  - chg: changed msg.error object to show all available error informations.
+                        This is an incompatible change and may affect your catch node(s) and failure reactions e.g. processing 'msg.error.message', so please adapt your flows accordingly.
+                        Example for an 'msg.error' <= Version 1.9.9:
+
+                        {
+                            name: "CtrlxProblemError",
+                            message: "DL_TYPE_MISMATCH",
+                            stack: ...
+                        }
+
+                        Example for an 'msg.error' >= Version 2.0.0:
+
+                        {
+                            name: "DL_TYPE_MISMATCH",
+                            message: 
+                                "{
+                                    "type": "about:blank",
+                                    "title": "DL_TYPE_MISMATCH",
+                                    "status": 400,
+                                    "detail": "1: 8: error: unknown field: a",
+                                    "instance": "sdk/net/provider/all-data/static/inertial-value",
+                                    "severity": "Error"
+                                }",
+                            stack: ...
+                        }       
 ```
 
 ## About

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ Any use of the source code and related documents of this repository in applicati
 * 2026-04-02: 1.9.9  - chore: upgrade internal development dependencies to newest version to mitigate for vulnerabilities. No runtime changes.
                      - fix: allow sampling interval = 0 in subscription properties, which indicates a real-time (RT) lossless subscriptions.
 * 2026-07-08: 2.0.0  - chg: changed msg.error object to show all available error informations.
-                        This is an incompatible change and may affect your catch node(s) and failure reactions e.g. processing 'msg.error.message', so please adapt your flows accordingly.
-                        Example for an 'msg.error' <= Version 1.9.9:
+                        ATTENTION: This is an incompatible change and may affect your catch node(s) and failure reactions e.g. processing 'msg.error.message', so please adapt your flows accordingly.
+                        Example for 'msg.error' <= Version 1.9.9:
 
                         {
                             name: "CtrlxProblemError",
@@ -134,7 +134,7 @@ Any use of the source code and related documents of this repository in applicati
                             stack: ...
                         }
 
-                        Example for an 'msg.error' >= Version 2.0.0:
+                        Example for 'msg.error' >= Version 2.0.0:
 
                         {
                             name: "DL_TYPE_MISMATCH",

--- a/README.md
+++ b/README.md
@@ -125,7 +125,11 @@ Any use of the source code and related documents of this repository in applicati
 * 2026-04-02: 1.9.9  - chore: upgrade internal development dependencies to newest version to mitigate for vulnerabilities. No runtime changes.
                      - fix: allow sampling interval = 0 in subscription properties, which indicates a real-time (RT) lossless subscriptions.
 * 2026-07-08: 2.0.0  - chg: changed msg.error object to show all available error informations.
-                        ATTENTION: This is an incompatible change and may affect your catch node(s) and failure reactions e.g. processing 'msg.error.message', so please adapt your flows accordingly.
+ 
+                        'msg.error.name':       The name of a Datalayer error, else the name of the HTTP error.
+                        'msg.error.message':    All available detailed informations of a Datalayer error as stringified JSON object, else the HTTP error text.
+
+                        ATTENTION: This is an incompatible change and may affect your catch node(s) and failure reactions on processing 'msg.error.name' or 'msg.error.message', so please check and adapt your flows accordingly!
                         Example for 'msg.error' <= Version 1.9.9:
 
                         {

--- a/lib/CtrlxProblemError.js
+++ b/lib/CtrlxProblemError.js
@@ -39,16 +39,16 @@ const STATUS_CODES = require('http').STATUS_CODES;
  */
 class CtrlxProblemError extends Error {
 
-  constructor(title, type) {
-    super(title);
+  constructor(name, message, type) {
+    super(message);
 
     // Maintains proper stack trace for where our error was thrown
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, CtrlxProblemError)
     }
 
-    this.name = 'CtrlxProblemError';
-    this._title = title;
+    this.name = name;
+    this._title = name;
     this._type = type;
     this._status = undefined;
     this._detail = undefined;
@@ -70,7 +70,7 @@ class CtrlxProblemError extends Error {
    */
   static fromHttpStatuscode(status) {
 
-    let ctrlXProblemError = new CtrlxProblemError(`[${status}] ${STATUS_CODES[status]}`, 'about:blank');
+    let ctrlXProblemError = new CtrlxProblemError(status, STATUS_CODES[status], 'about:blank');
     ctrlXProblemError._status = status;
 
     return ctrlXProblemError;
@@ -85,7 +85,7 @@ class CtrlxProblemError extends Error {
    * @memberof CtrlxProblemError
    */
   static fromEmptyHttpResponse(response) {
-    let ctrlXProblemError = new CtrlxProblemError(`[${response.statusCode}] ${response.statusMessage}`, 'about:blank');
+    let ctrlXProblemError = new CtrlxProblemError(response.statusCode, response.statusMessage, 'about:blank');
     ctrlXProblemError._status = response.statusCode;
 
     return ctrlXProblemError;
@@ -113,9 +113,8 @@ class CtrlxProblemError extends Error {
       // error class.
       let problem = JSON.parse(data);
 
-      let ctrlXProblemError = new CtrlxProblemError(problem.title, problem.type);
-      ctrlXProblemError._title = problem.title;
-      ctrlXProblemError._type = problem.type;
+      let ctrlXProblemError = new CtrlxProblemError(problem.title, JSON.stringify(problem, null, 2), problem.type);
+
       ctrlXProblemError._status = problem.status;
       ctrlXProblemError._detail = problem.detail;
       ctrlXProblemError._instance = problem.instance;

--- a/lib/CtrlxProblemError.js
+++ b/lib/CtrlxProblemError.js
@@ -85,7 +85,7 @@ class CtrlxProblemError extends Error {
    * @memberof CtrlxProblemError
    */
   static fromEmptyHttpResponse(response) {
-    let ctrlXProblemError = new CtrlxProblemError(response.statusCode, response.statusMessage, 'about:blank');
+    let ctrlXProblemError = new CtrlxProblemError(`[${response.statusCode}] ${STATUS_CODES[response.statusCode]}`, response.statusMessage, 'about:blank');
     ctrlXProblemError._status = response.statusCode;
 
     return ctrlXProblemError;

--- a/lib/CtrlxProblemError.js
+++ b/lib/CtrlxProblemError.js
@@ -70,7 +70,7 @@ class CtrlxProblemError extends Error {
    */
   static fromHttpStatuscode(status) {
 
-    let ctrlXProblemError = new CtrlxProblemError(status, STATUS_CODES[status], 'about:blank');
+    let ctrlXProblemError = new CtrlxProblemError(`[${status}] ${STATUS_CODES[status]}`, STATUS_CODES[status], 'about:blank');
     ctrlXProblemError._status = status;
 
     return ctrlXProblemError;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-ctrlx-automation",
-  "version": "1.9.9",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-ctrlx-automation",
-      "version": "1.9.9",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "atob": "^2.1.2",
@@ -17,14 +17,14 @@
       },
       "devDependencies": {
         "@types/chai": "^4.3.20",
-        "@types/node-red": "1.3.5",
+        "@types/node-red": "^1.3.5",
         "chai": "^4.5.0",
         "cors": "^2.8.5",
         "eslint": "^8.14.0",
         "eslint-plugin-mocha": "^10.0.4",
         "express": "^4.21.2",
         "jwt-simple": "^0.5.6",
-        "mocha": "^11.3.0",
+        "mocha": "^11.7.5",
         "node-red": "^4.1.8",
         "node-red-node-test-helper": "^0.3.0",
         "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-ctrlx-automation",
-  "version": "1.9.9",
+  "version": "2.0.0",
   "description": "Node-RED nodes for ctrlX AUTOMATION",
   "repository": {
     "type": "git",

--- a/test/CtrlxCore.nodes.test.js
+++ b/test/CtrlxCore.nodes.test.js
@@ -431,7 +431,7 @@ describe('CtrlxCoreDataLayerNodes', function() {
         .then(() => ctrlx.datalayerReadMetadata('invalidnode'))
         .then((data) => done(new Error("should not reach this code. Expected error instead of: " + JSON.stringify(data))))
         .catch((err) => {
-          expect(err.name).equal(404);
+          expect(err.name).equal('[404] Not Found');
           expect(err.message).equal('Not Found');
 
           expect(err.status).equal(404);

--- a/test/CtrlxCore.nodes.test.js
+++ b/test/CtrlxCore.nodes.test.js
@@ -430,8 +430,7 @@ describe('CtrlxCoreDataLayerNodes', function() {
         .then(() => ctrlx.datalayerReadMetadata('invalidnode'))
         .then((data) => done(new Error("should not reach this code. Expected error instead of: " + JSON.stringify(data))))
         .catch((err) => {
-          console.debug(err);
-          expect(err.name).equal('[404] Not Found');
+          expect(err.name).equal(404);
           expect(err.message).equal('Not Found');
           expect(err.status).equal(404);
 
@@ -449,20 +448,19 @@ describe('CtrlxCoreDataLayerNodes', function() {
         .then(() => ctrlx.datalayerRead('nonexistent/path'))
         .then((data) => done(new Error("should not reach this code. Expected error instead of: " + JSON.stringify(data))))
         .catch((err) => {
-          console.debug(err);
           expect(err.name).equal('Error on Read');
-          expect(err.message).equal('Your current balance is 30, but that costs 50.');
+          expect(err.message).equal('{\n  "title": "Error on Read",\n  "type": "about:blank",\n  "status": 404,\n  "detail": "Your current balance is 30, but that costs 50.",\n  "instance": "/account/12345/msgs/abc",\n  "mainDiagnosisCode": "F0360001",\n  "detailedDiagnosisCode": "00666001",\n  "dynamicDescription": "This could be a dynamic description",\n  "severity": "ERROR"\n}');
 
-          expect(err.title).to.be.a('string');
+          expect(err.title).equal('Error on Read');
           expect(err.type).equal('about:blank');
           expect(err.severity).equal('ERROR');
           expect(err.type).to.be.a('string');
           expect(err.status).equal(404);
-          expect(err.detail).to.be.a('string');
-          expect(err.instance).to.be.a('string');
-          expect(err.mainDiagnosisCode).to.be.a('string').with.length(8);
-          expect(err.detailedDiagnosisCode).to.be.a('string').with.length(8);
-          expect(err.dynamicDescription).to.be.a('string');
+          expect(err.detail).equal('Your current balance is 30, but that costs 50.');
+          expect(err.instance).equal('/account/12345/msgs/abc');
+          expect(err.mainDiagnosisCode).equal('F0360001');
+          expect(err.detailedDiagnosisCode).equal('00666001');
+          expect(err.dynamicDescription).equal('This could be a dynamic description');
 
           const message = err.toStringExtended();
           expect(message).to.not.include('about:blank');

--- a/test/CtrlxCore.nodes.test.js
+++ b/test/CtrlxCore.nodes.test.js
@@ -388,19 +388,19 @@ describe('CtrlxCoreDataLayerNodes', function() {
 
       ctrlx.datalayerRead('framework/metrics/system/cpu-utilisation-percent')
         .then((data) => done(new Error("should not reach this code. Expected error instead of: " + JSON.stringify(data))))
-        .catch((err) => { assert.equal(err.name, 'Error'); })
+        .catch((err) => { expect(err.name).equal('Error'); })
         .finally(() => ctrlx.logOut());
       ctrlx.datalayerReadMetadata('framework/metrics/system/cpu-utilisation-percent')
         .then((data) => done(new Error("should not reach this code. Expected error instead of: " + JSON.stringify(data))))
-        .catch((err) => { assert.equal(err.name, 'Error'); })
+        .catch((err) => { expect(err.name).equal('Error'); })
         .finally(() => ctrlx.logOut());
       ctrlx.datalayerWrite('framework/metrics/system/cpu-utilisation-percent', { value: '5', type: 'double' })
         .then((data) => done(new Error("should not reach this code. Expected error instead of: " + JSON.stringify(data))))
-        .catch((err) => { assert.equal(err.name, 'Error'); })
+        .catch((err) => { expect(err.name).equal('Error'); })
         .finally(() => ctrlx.logOut());
       ctrlx.datalayerBrowse('framework/metrics/system/cpu-utilisation-percent')
         .then((data) => done(new Error("should not reach this code. Expected error instead of: " + JSON.stringify(data))))
-        .catch((err) => { assert.equal(err.name, 'Error'); })
+        .catch((err) => { expect(err.name).equal('Error'); })
         .finally(() => ctrlx.logOut());
       done();
     });
@@ -413,8 +413,10 @@ describe('CtrlxCoreDataLayerNodes', function() {
       ctrlx.logIn()
         .then((data) => done(new Error("should not reach this code. Expected error instead of: " + JSON.stringify(data))))
         .catch((err) => {
-          assert.equal(err.name, 'CtrlxProblemError');
-          assert.equal(err.status, 401);
+          console.log(err.name, err.message, err.status, err);
+          expect(err.name).equal('[401] Unauthorized unknown error');
+          expect(err.message).equal('Unauthorized unknown error');
+          expect(err.status).equal(401);
           done();
         })
         .finally(() => ctrlx.logOut());
@@ -429,7 +431,11 @@ describe('CtrlxCoreDataLayerNodes', function() {
         .then(() => ctrlx.datalayerReadMetadata('invalidnode'))
         .then((data) => done(new Error("should not reach this code. Expected error instead of: " + JSON.stringify(data))))
         .catch((err) => {
-          assert.equal(err.name, 'CtrlxProblemError');
+          console.debug(err);
+          expect(err.name).equal('[404] Not Found');
+          expect(err.message).equal('Not Found');
+          expect(err.status).equal(404);
+
           done();
         })
         .finally(() => ctrlx.logOut());
@@ -444,12 +450,15 @@ describe('CtrlxCoreDataLayerNodes', function() {
         .then(() => ctrlx.datalayerRead('nonexistent/path'))
         .then((data) => done(new Error("should not reach this code. Expected error instead of: " + JSON.stringify(data))))
         .catch((err) => {
-          expect(err.name).equal('CtrlxProblemError');
+          console.debug(err);
+          expect(err.name).equal('Error on Read');
+          expect(err.message).equal('Your current balance is 30, but that costs 50.');
+
           expect(err.title).to.be.a('string');
-          expect(err.type).to.be.a('string').equal('about:blank');
-          expect(err.severity).to.be.a('string').equal('ERROR');
+          expect(err.type).equal('about:blank');
+          expect(err.severity).equal('ERROR');
           expect(err.type).to.be.a('string');
-          expect(err.status).to.be.a('number').equal(404);
+          expect(err.status).equal(404);
           expect(err.detail).to.be.a('string');
           expect(err.instance).to.be.a('string');
           expect(err.mainDiagnosisCode).to.be.a('string').with.length(8);
@@ -473,15 +482,25 @@ describe('CtrlxCoreDataLayerNodes', function() {
     it('should create a CtrlxProblemError from http status code', function() {
 
       let err = CtrlxProblemError.fromHttpStatuscode(404);
-      expect(err.status).to.be.a('number').equal(404);
-      expect(err.title).to.be.a('string').equal('[404] Not Found');
+
+      expect(err.name).equal('[404] Not Found');
+      expect(err.message).equal('Not Found');
+
+      expect(err.type).to.equal('about:blank');
+      expect(err.status).equal(404);
+      expect(err.title).equal('[404] Not Found');
       expect(err.toStringExtended()).to.include('[404] Not Found');
     });
 
     it('should return CtrlxProblemError type only if set', function() {
 
       let err = CtrlxProblemError.fromHttpStatuscode(404);
+
+      expect(err.name).equal('[404] Not Found');
+      expect(err.message).equal('Not Found');
+
       expect(err.type).to.equal('about:blank');
+      expect(err.status).equal(404);
       expect(err.toStringExtended()).to.not.include('about:blank');
       err._type = 'https://example.com/probs/out-of-credit';
       expect(err.toStringExtended()).to.include('https://example.com/probs/out-of-credit');

--- a/test/CtrlxCore.nodes.test.js
+++ b/test/CtrlxCore.nodes.test.js
@@ -413,9 +413,8 @@ describe('CtrlxCoreDataLayerNodes', function() {
       ctrlx.logIn()
         .then((data) => done(new Error("should not reach this code. Expected error instead of: " + JSON.stringify(data))))
         .catch((err) => {
-          console.log(err.name, err.message, err.status, err);
-          expect(err.name).equal('[401] Unauthorized unknown error');
-          expect(err.message).equal('Unauthorized unknown error');
+          expect(err.name).equal('[401] Unauthorized');
+          expect(err.message).equal('Unauthorized');
           expect(err.status).equal(401);
           done();
         })

--- a/test/CtrlxCore.nodes.test.js
+++ b/test/CtrlxCore.nodes.test.js
@@ -415,6 +415,7 @@ describe('CtrlxCoreDataLayerNodes', function() {
         .catch((err) => {
           expect(err.name).equal('[401] Unauthorized');
           expect(err.message).equal('Unauthorized');
+
           expect(err.status).equal(401);
           done();
         })
@@ -432,6 +433,7 @@ describe('CtrlxCoreDataLayerNodes', function() {
         .catch((err) => {
           expect(err.name).equal(404);
           expect(err.message).equal('Not Found');
+
           expect(err.status).equal(404);
 
           done();
@@ -451,10 +453,9 @@ describe('CtrlxCoreDataLayerNodes', function() {
           expect(err.name).equal('Error on Read');
           expect(err.message).equal('{\n  "title": "Error on Read",\n  "type": "about:blank",\n  "status": 404,\n  "detail": "Your current balance is 30, but that costs 50.",\n  "instance": "/account/12345/msgs/abc",\n  "mainDiagnosisCode": "F0360001",\n  "detailedDiagnosisCode": "00666001",\n  "dynamicDescription": "This could be a dynamic description",\n  "severity": "ERROR"\n}');
 
-          expect(err.title).equal('Error on Read');
+          expect(err.title).equal(err.name);
           expect(err.type).equal('about:blank');
           expect(err.severity).equal('ERROR');
-          expect(err.type).to.be.a('string');
           expect(err.status).equal(404);
           expect(err.detail).equal('Your current balance is 30, but that costs 50.');
           expect(err.instance).equal('/account/12345/msgs/abc');
@@ -462,13 +463,13 @@ describe('CtrlxCoreDataLayerNodes', function() {
           expect(err.detailedDiagnosisCode).equal('00666001');
           expect(err.dynamicDescription).equal('This could be a dynamic description');
 
-          const message = err.toStringExtended();
-          expect(message).to.not.include('about:blank');
-          expect(message).to.include(err.title);
-          expect(message).to.include(err.severity);
-          expect(message).to.include(err.detail);
-          expect(message).to.include(err.mainDiagnosisCode);
-          expect(message).to.include(err.detailedDiagnosisCode);
+          const ext = err.toStringExtended();
+          expect(ext).to.not.include('about:blank');
+          expect(ext).to.include(err.title);
+          expect(ext).to.include(err.severity);
+          expect(ext).to.include(err.detail);
+          expect(ext).to.include(err.mainDiagnosisCode);
+          expect(ext).to.include(err.detailedDiagnosisCode);
 
           done();
         })
@@ -483,9 +484,10 @@ describe('CtrlxCoreDataLayerNodes', function() {
       expect(err.name).equal('[404] Not Found');
       expect(err.message).equal('Not Found');
 
-      expect(err.type).to.equal('about:blank');
       expect(err.status).equal(404);
-      expect(err.title).equal('[404] Not Found');
+      expect(err.type).to.equal('about:blank');
+      expect(err.title).equal(err.name);
+
       expect(err.toStringExtended()).to.include('[404] Not Found');
     });
 
@@ -498,6 +500,7 @@ describe('CtrlxCoreDataLayerNodes', function() {
 
       expect(err.type).to.equal('about:blank');
       expect(err.status).equal(404);
+
       expect(err.toStringExtended()).to.not.include('about:blank');
       err._type = 'https://example.com/probs/out-of-credit';
       expect(err.toStringExtended()).to.include('https://example.com/probs/out-of-credit');


### PR DESCRIPTION
chg: changed msg.error object to show all available error informations.
 
                        'msg.error.name':       The name of a Datalayer error, else the name of the HTTP error.
                        'msg.error.message':    All available detailed informations of a Datalayer error as stringified JSON object, else the HTTP error text.

                        ATTENTION: This is an incompatible change and may affect your catch node(s) and failure reactions on processing 'msg.error.name' or 'msg.error.message', so please check and adapt your flows accordingly!
                        Example for 'msg.error' <= Version 1.9.9:

                        {
                            name: "CtrlxProblemError",
                            message: "DL_TYPE_MISMATCH",
                            stack: ...
                        }

                        Example for 'msg.error' >= Version 2.0.0:

                        {
                            name: "DL_TYPE_MISMATCH",
                            message: 
                                "{
                                    "type": "about:blank",
                                    "title": "DL_TYPE_MISMATCH",
                                    "status": 400,
                                    "detail": "1: 8: error: unknown field: a",
                                    "instance": "sdk/net/provider/all-data/static/inertial-value",
                                    "severity": "Error"
                                }",
                            stack: ...
                        }       